### PR TITLE
Reduce size of pubsub-emulator docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Google Cloud Pub/Sub Documentation
 # https://cloud.google.com/pubsub/docs/
 
-FROM google/cloud-sdk
-LABEL maintainer="Cesar Perez <cesar@bigtruedata.com>" \
-      version="0.1" \
-      description="Google Cloud Pub/Sub Emulator"
+FROM google/cloud-sdk:alpine
+RUN apk --update add openjdk7-jre
+RUN gcloud components install --quiet beta pubsub-emulator
+
+VOLUME /data 
 
 EXPOSE 8538
 
-VOLUME /data
-
-ENTRYPOINT ["gcloud", "beta", "emulators", "pubsub"]
-CMD ["start", "--host-port=127.0.0.1:8538", "--data-dir=/data"]
+CMD ["gcloud", "beta", "emulators", "pubsub", "start", "--quiet",  "--data-dir=/data", "--host-port=0.0.0.0:8538"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This image provides a dockerized version of the *Google Cloud Pub/Sub Emulator*.
 The following shell statement show the most simple execution of the provided image. It will execute the *Pub/Sub Emulator* that will listen on port 8538.
 
 ```sh
-docker run --rm --tty --interactive --publish 8538:8538i eu.gcr.io/census-ci/gcloud-pubsub-emulator
+docker run --rm --tty --interactive --publish 8538:8538 eu.gcr.io/census-ci/gcloud-pubsub-emulator
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker run --rm --tty --interactive --publish 8538:8538i eu.gcr.io/census-ci/gcl
 ```
 
 ## Configuration
-The most important configuration parameters of the *Pub/Sub emulator* image are the host/port value the server will listen on and the directory where data files will be placed. By default, the image is configured to listen on `127.0.0.1:8538` and store its files in the `/data` directory. This behavior can be changed by providing the correct command-line options.
+The most important configuration parameters of the *Pub/Sub emulator* image are the host/port value the server will listen on and the directory where data files will be placed. By default, the image is configured to listen on `0.0.0.0:8538` and store its files in the `/data` directory. This behavior can be changed by providing the correct command-line options.
 
 The following example shows how to start the *Pub/Sub emulator* to listen on `192.168.1.3:12345` and to store its files in the `/pubsub-data` directory.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Docker Automated Build](https://img.shields.io/docker/automated/bigtruedata/gcloud-pubsub-emulator.svg)](https://hub.docker.com/r/bigtruedata/gcloud-pubsub-emulator/) [![Docker Build Status](https://img.shields.io/docker/build/bigtruedata/gcloud-pubsub-emulator.svg)](https://hub.docker.com/r/bigtruedata/gcloud-pubsub-emulator/builds/) [![Docker Pulls](https://img.shields.io/docker/pulls/bigtruedata/gcloud-pubsub-emulator.svg)](https://hub.docker.com/r/bigtruedata/gcloud-pubsub-emulator/) [![Docker Stars](https://img.shields.io/docker/stars/bigtruedata/gcloud-pubsub-emulator.svg)](https://hub.docker.com/r/bigtruedata/gcloud-pubsub-emulator/) [![License](https://img.shields.io/github/license/bigtruedata/docker-gcloud-pubsub-emulator.svg)](https://raw.githubusercontent.com/bigtruedata/docker-gcloud-pubsub-emulator/blob/master/LICENSE.md)
-
-# [Google Cloud Pub/Sub Emulator Image](https://hub.docker.com/r/bigtruedata/gcloud-pubsub-emulator/)
+# Google Cloud Pub/Sub Emulator Image
 
 [*Cloud Pub/Sub*](https://cloud.google.com/pubsub/) is a global service for real-time and reliable messaging and streaming data
 
@@ -10,30 +8,7 @@ This image provides a dockerized version of the *Google Cloud Pub/Sub Emulator*.
 The following shell statement show the most simple execution of the provided image. It will execute the *Pub/Sub Emulator* that will listen on port 8538.
 
 ```sh
-docker run --rm --tty --interactive --publish 8538:8538 bigtruedata/gcloud-pubsub-emulator
-```
-
-The image is much more useful when it is used in a CD/CI automated environment. The following example shows how to configure the *Pub/Sub Emulator* to be used in a [*Wercker*](http://www.wercker.com/) development pipeline.
-
-```sh
-box: python:3.5
-
-dev:
-  services:
-    - name: pubsub
-      id: bigtruedata/gcloud-pubsub-emulator
-      cmd: start --host-port 0.0.0.0:8538
-
-  steps:
-    - script:
-      name: Define Pub/Sub environment variables
-      code: |
-        ADDR=$PUBSUB_PORT_8538_TCP_ADDR
-        PORT=$PUBSUB_PORT_8538_TCP_PORT
-        export PUBSUB_EMULATOR_HOST=$ADDR:$PORT
-
-    - internal/shell:
-      cmd: bash
+docker run --rm --tty --interactive --publish 8538:8538i eu.gcr.io/census-ci/gcloud-pubsub-emulator
 ```
 
 ## Configuration
@@ -42,7 +17,5 @@ The most important configuration parameters of the *Pub/Sub emulator* image are 
 The following example shows how to start the *Pub/Sub emulator* to listen on `192.168.1.3:12345` and to store its files in the `/pubsub-data` directory.
 
 ```sh
-docker run --rm --tty --interactive bigtruedata/gcloud-pubsub-emulator start --host-port=192.168.1.3:12345 --data-dir=/pubsub-data
+docker run --rm --tty --interactive eu.gcr.io/census-ci/gcloud-pubsub-emulator start --host-port=192.168.1.3:12345 --data-dir=/pubsub-data
 ```
-
-**NOTE**: Wercker's documentation can be checked online on [Wercker Documentation Website](http://devcenter.wercker.com/docs/home)


### PR DESCRIPTION
PR to merge in Dockerfile changes to reduce the size of the pubsub-emulator docker image. The docker image has already been built and pushed to eu.gcr.io/census-ci/gcloud-pubsub-emulator so this PR is more of a formality.

The image now uses the gcloud/sdk:alpine as a base image which does not include any of the components, so pubsub-emulator and beta commands are installed as part of the build. This reduced the size from approx 1.7 GB to approx 700 MB.

https://trello.com/c/9F2Wp1k3/534-reduce-size-of-pubsub-emulator-docker-image